### PR TITLE
Add PHP Curl to support S3 attachments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get -y install \
   php5-fpm \
   php5-imap \
   php5-gd \
+  php5-curl \
   php5-mysql && \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Without PHP Curl the plugin for storing attachments in S3 doesn't work. This fixes that issue.